### PR TITLE
Fix URLs in .github template files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,15 +7,15 @@ well.
 There are many ways you can contribute! :heart:
 
 ### Bug Reports and Fixes :bug:
--  If you find a bug, please search for it in the [Issues](https://github.com/{project_slug}/issues), and if it isn't already tracked,
-   [create a new issue](https://github.com/{project_slug}/issues/new). Fill out the "Bug Report" section of the issue template. Even if an Issue is closed, feel free to comment and add details, it will still
+-  If you find a bug, please search for it in the [Issues](https://github.com/slackhq/moshi-gson-interop/issues), and if it isn't already tracked,
+   [create a new issue](https://github.com/slackhq/moshi-gson-interop/issues/new). Fill out the "Bug Report" section of the issue template. Even if an Issue is closed, feel free to comment and add details, it will still
    be reviewed.
 -  Issues that have already been identified as a bug (note: able to reproduce) will be labelled `bug`.
 -  If you'd like to submit a fix for a bug, [send a Pull Request](#creating_a_pull_request) and mention the Issue number.
   -  Include tests that isolate the bug and verifies that it was fixed.
 
 ### New Features :bulb:
--  If you'd like to add new functionality to this project, describe the problem you want to solve in a [new Issue](https://github.com/{project_slug}/issues/new).
+-  If you'd like to add new functionality to this project, describe the problem you want to solve in a [new Issue](https://github.com/slackhq/moshi-gson-interop/issues/new).
 -  Issues that have been identified as a feature request will be labelled `enhancement`.
 -  If you'd like to implement the new feature, please wait for feedback from the project
    maintainers before spending too much time writing the code. In some cases, `enhancement`s may
@@ -26,7 +26,7 @@ There are many ways you can contribute! :heart:
    alternative implementation of something that may have advantages over the way its currently
    done, or you have any other change, we would be happy to hear about it!
   -  If its a trivial change, go ahead and [send a Pull Request](#creating_a_pull_request) with the changes you have in mind.
-  -  If not, [open an Issue](https://github.com/{project_slug}/issues/new) to discuss the idea first.
+  -  If not, [open an Issue](https://github.com/slackhq/moshi-gson-interop/issues/new) to discuss the idea first.
 
 If you're new to our project and looking for some way to make your first contribution, look for
 Issues labelled `good first contribution`.
@@ -35,7 +35,7 @@ Issues labelled `good first contribution`.
 
 For your contribution to be accepted:
 
-- [x] You must have signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
+- [x] You must have signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/moshi-gson-interop).
 - [x] The test suite must be complete and pass.
 - [x] The changes must be approved by code review.
 - [x] Commits should be atomic and messages must be descriptive. Related issues should be mentioned by Issue number.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 ### Requirements (place an `x` in each `[ ]`)
 
-* [ ] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/contributing.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/moshi-gson-interop/blob/main/.github/contributing.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
 
 > The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)
@@ -13,4 +13,4 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 > The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io
 
-* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
+* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/moshi-gson-interop).


### PR DESCRIPTION
###  Summary

Replace the `{project_slug}` placeholder in .github template files with the actual value (`slackhq/moshi-gson-interop`). GitHub doesn't seem to be doing this automatically. So links in e.g. this PR description are broken.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
