### PR TITLE
Fix link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 ### Requirements (place an `x` in each `[ ]`)
 
-* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/moshi-gson-interop/blob/main/.github/contributing.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/moshi-gson-interop/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
 
 > The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)


### PR DESCRIPTION
###  Summary

Guess who checked all the links for PR #8 and then forgot to fix the file name in the Contributing Guidelines link :disappointed: 


### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/moshi-gson-interop/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/moshi-gson-interop).
