### PR TITLE
Fix reference to outdated API in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ general-purpose tool that should be used for other reasons.
 ## Usage
 
 In order to properly link two `Moshi` and `Gson` instances, you must pass two _complete_
-instances (i.e. not intended to `newBuilder()` later) to `wireMoshiGsonInterop()` and use
+instances (i.e. not intended to `newBuilder()` later) to `Moshi.interopWith()` and use
 the returned instances.
 
 ```kotlin


### PR DESCRIPTION
###  Summary

Replace reference to outdated method `wireMoshiGsonInterop` with the final API.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/moshi-gson-interop/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/moshi-gson-interop).

### Note

Please feel free to just close this PR if you want to change the wording some more.