### PR TITLE
Avoid JsonElement/JsonValue APIs to better preserve encoding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,11 +19,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URL
 
 plugins {
-  kotlin("jvm") version "1.4.10"
-  id("org.jetbrains.dokka") version "1.4.10"
-  id("com.diffplug.spotless") version "5.6.0"
+  kotlin("jvm") version "1.4.30"
+  id("org.jetbrains.dokka") version "1.4.20"
+  id("com.diffplug.spotless") version "5.9.0"
   id("com.vanniktech.maven.publish") version "0.13.0"
-  id("io.gitlab.arturbosch.detekt") version "1.13.1"
+  id("io.gitlab.arturbosch.detekt") version "1.15.0"
 }
 
 repositories {
@@ -112,5 +112,5 @@ dependencies {
 
   testImplementation("com.squareup.moshi:moshi-kotlin:$moshiVersion")
   testImplementation("junit:junit:4.13.1")
-  testImplementation("com.google.truth:truth:1.0.1")
+  testImplementation("com.google.truth:truth:1.1.2")
 }

--- a/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
+++ b/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
@@ -264,7 +264,7 @@ private fun read(reader: GsonReader, builder: StringBuilder) {
     }
     JsonToken.NUMBER -> {
       // This allows moshi-gson-interop to preserve encoding from the reader,
-      // avoiding issues like Gson's JsonElement API converting all 
+      // avoiding issues like Gson's JsonElement API converting all
       // numbers potentially to Doubles.
       val lenient = reader.isLenient
       try {
@@ -344,7 +344,7 @@ private fun GsonWriter.write(reader: JsonReader) {
     Token.STRING -> value(reader.nextString())
     Token.NUMBER -> {
       // This allows moshi-gson-interop to preserve encoding from the reader,
-      // avoiding issues like Moshi's `toJsonValue` API converting all 
+      // avoiding issues like Moshi's `toJsonValue` API converting all
       // numbers potentially to Doubles.
       val lenient = reader.isLenient
       try {

--- a/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
+++ b/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
@@ -254,6 +254,7 @@ private fun parseStringFromReader(reader: GsonReader): String {
 }
 
 /** Streams the contents of a given Gson [reader] into the target [builder]. */
+@Suppress("LongMethod")
 private fun read(reader: GsonReader, builder: StringBuilder) {
   when (val token = reader.peek()) {
     JsonToken.STRING -> {

--- a/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
+++ b/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
@@ -253,7 +253,7 @@ private fun parseStringFromReader(reader: GsonReader): String {
   }
 }
 
-/** Streams the contents of a given Gson [reader] into the target [builder]. */
+/** Streams the contents of a given Gson [reader] into the target [builder] as a raw JSON string. */
 @Suppress("LongMethod")
 private fun read(reader: GsonReader, builder: StringBuilder) {
   when (val token = reader.peek()) {

--- a/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
+++ b/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
@@ -257,6 +257,7 @@ private fun GsonReader.readTo(builder: StringBuilder) {
       // avoiding issues like Gson's JsonElement API converting all
       // numbers potentially to Doubles.
       val lenient = isLenient
+      isLenient = true
       try {
         builder.append(nextString())
       } finally {
@@ -337,6 +338,7 @@ private fun GsonWriter.write(reader: JsonReader) {
       // avoiding issues like Moshi's `toJsonValue` API converting all
       // numbers potentially to Doubles.
       val lenient = reader.isLenient
+      reader.isLenient = true
       try {
         value(reader.nextString())
       } finally {

--- a/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
+++ b/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
@@ -218,7 +218,8 @@ internal class MoshiDelegatingTypeAdapter<T>(
     val serializedValue = adjustedDelegate.toJson(value)
     if (writer is JsonTreeWriter) {
       // See https://github.com/slackhq/moshi-gson-interop/issues/22
-      // Even with https://github.com/google/gson/pull/1819, using JsonElement is not enough because
+      // Even with https://github.com/google/gson/pull/1819, using JsonElement is not enough
+      // because of the above Double conversions.
       val buffer = Buffer()
       buffer.writeUtf8(serializedValue)
       val reader = JsonReader.of(buffer)

--- a/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
+++ b/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
@@ -237,7 +237,7 @@ internal class MoshiDelegatingTypeAdapter<T>(
 }
 
 /** Converts a [GsonReader] to an encoded String for use with [JsonAdapter.fromJson]. */
-internal fun parseStringFromReader(reader: GsonReader): String {
+private fun parseStringFromReader(reader: GsonReader): String {
   val lenient = reader.isLenient
   reader.isLenient = true
   return try {

--- a/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
+++ b/src/main/kotlin/com/slack/moshi/interop/gson/InteropBuilder.kt
@@ -263,9 +263,9 @@ private fun read(reader: GsonReader, builder: StringBuilder) {
       builder.append('"')
     }
     JsonToken.NUMBER -> {
-      // This allows moshi-gson-interop to preserve encoding from the reader.
-      // exactly as it's encoded, avoiding issues like Gson's JsonElement API
-      // converting all numbers potentially to Doubles.
+      // This allows moshi-gson-interop to preserve encoding from the reader,
+      // avoiding issues like Gson's JsonElement API converting all 
+      // numbers potentially to Doubles.
       val lenient = reader.isLenient
       try {
         builder.append(reader.nextString())
@@ -343,9 +343,9 @@ private fun GsonWriter.write(reader: JsonReader) {
     }
     Token.STRING -> value(reader.nextString())
     Token.NUMBER -> {
-      // This allows moshi-gson-interop to preserve encoding from the reader.
-      // exactly as it's encoded, avoiding issues like Moshi's `toJsonValue()` API
-      // converting all numbers to Doubles.
+      // This allows moshi-gson-interop to preserve encoding from the reader,
+      // avoiding issues like Moshi's `toJsonValue` API converting all 
+      // numbers potentially to Doubles.
       val lenient = reader.isLenient
       try {
         value(reader.nextString())


### PR DESCRIPTION
This helps us avoid accidentally changed encoding of data during interop. `JsonElement` and Moshi's `toJsonValue()` APIs will convert numbers potentially into Doubles. While functionally this may be fine, we've seen cases where lenient parsing of Strings on number literals result in technically different values. i.e. parsing `123` as a `String`, then suddenly getting `123.0` for that `String` after interop.

This also opportunistically updates dependencies, namely Kotlin 1.4.30