### PR TITLE
Repro exclusiveContent issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,6 @@ plugins {
 }
 
 repositories {
-  mavenCentral()
   exclusiveContent {
     forRepository {
       maven {
@@ -42,6 +41,7 @@ repositories {
       includeModule("org.jetbrains", "markdown")
     }
   }
+  mavenCentral()
 }
 
 java {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,22 @@
+pluginManagement {
+  repositories {
+    exclusiveContent {
+      forRepository {
+        maven {
+          name = "JCenter"
+          setUrl("https://jcenter.bintray.com/")
+        }
+      }
+      filter {
+        // Required for Dokka
+        includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
+        includeGroup("org.jetbrains.dokka")
+        includeModule("org.jetbrains", "markdown")
+      }
+    }
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+
+rootProject.name = "moshi-gson-interop"


### PR DESCRIPTION
Even though jcenter is defined via exclusiveContent, it still takes precedence. Almost every dependency runs through it: https://scans.gradle.com/s/2bd46wed5yqjs/build-dependencies/repositories?repoToggled=W1swXSxbMCwwXSxbMV0sWzEsMF1d#focusedRepository=j-center
