### PR TITLE
Try/catch getField in EnumClassChecker

### DIFF
--- a/src/main/kotlin/com/slack/moshi/interop/gson/ClassCheckers.kt
+++ b/src/main/kotlin/com/slack/moshi/interop/gson/ClassCheckers.kt
@@ -85,7 +85,11 @@ public class EnumClassChecker(
       @Suppress("UNCHECKED_CAST")
       val constants: Array<out Enum<*>> = rawType.enumConstants as Array<out Enum<*>>
       for (constant in constants) {
-        val field = rawType.getField(constant.name)
+        val field = try {
+          rawType.getField(constant.name)
+        } catch (e: NoSuchFieldException) {
+          return null
+        }
         if (field.isAnnotationPresent(SerializedName::class.java)) {
           logger?.invoke("🧠 Picking GSON for enum $rawType based on @SerializedName-annotated member $field.")
           return GSON

--- a/src/main/kotlin/com/slack/moshi/interop/gson/ClassCheckers.kt
+++ b/src/main/kotlin/com/slack/moshi/interop/gson/ClassCheckers.kt
@@ -85,6 +85,7 @@ public class EnumClassChecker(
       @Suppress("UNCHECKED_CAST")
       val constants: Array<out Enum<*>> = rawType.enumConstants as Array<out Enum<*>>
       for (constant in constants) {
+        @Suppress("SwallowedException")
         val field = try {
           rawType.getField(constant.name)
         } catch (e: NoSuchFieldException) {


### PR DESCRIPTION
R8 may inline these away so we should just gracefully fall back

Not able to reliably create a test for this as it requires R8-style bytecode manipulation